### PR TITLE
CGI param() throws warning if is used in the list context 

### DIFF
--- a/lib/CGI/FormBuilder.pm
+++ b/lib/CGI/FormBuilder.pm
@@ -844,8 +844,7 @@ sub keepextras {
     } else {
         # Set to "1", so must go thru all params, skipping 
         # leading underscore fields and form fields
-        my @params = $self->{params}->can('multi_param') ? $self->{params}->multi_param() : $self->{params}->param();
-        for my $p (@params) {
+        for my $p ($self->{params}->param()) {
             next if $p =~ /^_/  || $self->{fieldrefs}{$p};
             push @keep, $p;
         }

--- a/lib/CGI/FormBuilder.pm
+++ b/lib/CGI/FormBuilder.pm
@@ -844,6 +844,7 @@ sub keepextras {
     } else {
         # Set to "1", so must go thru all params, skipping 
         # leading underscore fields and form fields
+        my @values = $self->{params}->can('multi_param') ? $self->{params}->multi_param() : $self->{params}->param();
         for my $p ($self->{params}->param) {
             next if $p =~ /^_/  || $self->{fieldrefs}{$p};
             push @keep, $p;
@@ -855,7 +856,8 @@ sub keepextras {
 
     # Make sure to get all values
     for my $p (@keep) {
-        for my $v ($self->{params}->param($p)) {
+        my @values = $self->{params}->can('multi_param') ? $self->{params}->multi_param($p) : $self->{params}->param($p);
+        for my $v (@values) {
             debug 1, "keepextras: saving hidden param $p = $v";
             push @html, htmltag('input', name => $p, type => 'hidden', value => $v);
         }

--- a/lib/CGI/FormBuilder.pm
+++ b/lib/CGI/FormBuilder.pm
@@ -844,8 +844,8 @@ sub keepextras {
     } else {
         # Set to "1", so must go thru all params, skipping 
         # leading underscore fields and form fields
-        my @values = $self->{params}->can('multi_param') ? $self->{params}->multi_param() : $self->{params}->param();
-        for my $p ($self->{params}->param) {
+        my @params = $self->{params}->can('multi_param') ? $self->{params}->multi_param() : $self->{params}->param();
+        for my $p (@params) {
             next if $p =~ /^_/  || $self->{fieldrefs}{$p};
             push @keep, $p;
         }

--- a/lib/CGI/FormBuilder/Field.pm
+++ b/lib/CGI/FormBuilder/Field.pm
@@ -50,7 +50,6 @@ no  warnings 'uninitialized';
 
 use CGI::FormBuilder::Util;
 
-
 our $VERSION = '3.08';
 our $AUTOLOAD;
 
@@ -189,7 +188,7 @@ sub cgi_value {
     my $self = shift;
     debug 2, "$self->{name}: called \$field->cgi_value";
     puke "Cannot set \$field->cgi_value manually" if @_;
-    if (my @v = $self->{_form}{params}->param($self->name)) {
+    if (my @v = $self->{_form}{params}->can('multi_param') ? $self->{_form}{params}->multi_param($self->name) : $self->{_form}{params}->param($self->name)) {
         for my $v (@v) {
             if ($self->other && $v eq $self->othername) {
                 debug 1, "$self->{name}: redoing value from _other field";


### PR DESCRIPTION
Check https://metacpan.org/pod/CGI#Fetching-the-value-or-values-of-a-single-named-parameter
I've replaced the param() with multi_param() if CGI.pm has this method, to eliminate this warning.