### PR TITLE
support for "gimsu" js pattern match modifiers

### DIFF
--- a/lib/CGI/FormBuilder/Field.pm
+++ b/lib/CGI/FormBuilder/Field.pm
@@ -611,11 +611,11 @@ sub jsfield {
                      ? qq[$jsfield == null ||]                     # must have or error
                      : qq[$jsfield != null && $jsfield != "" &&];  # only care if filled in
 
-    if ($pattern =~ m#^m?(\S)(.*)\1$#) {
+    if ($pattern =~ m#^m?(\S)(.*)\1([gimsu]+)?$#) {
         # JavaScript regexp
         ($pattern = $2) =~ s/\\\//\//g;
         $pattern =~ s/\//\\\//g;
-        $jsfunc .= qq[${in}if ($notnull ! $jsfield.match(/$pattern/)) {\n];
+        $jsfunc .= qq[${in}if ($notnull ! $jsfield.match(/$pattern/$3)) {\n];
     }
     elsif (ref $pattern eq 'ARRAY') {
         # Must be w/i this set of values


### PR DESCRIPTION
Allows using /u, /i etc. on javascript regex validation patterns.  'y' didn't seem to make sense the way FB puts it together, so I omitted that.  Not sure 'g' really makes sense either but it doesn't have an effect on subsequent matches so who cares.